### PR TITLE
[修正] リンクボタンの当たり判定を四角の端まで広げました

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,18 +12,21 @@
         <p class="mt-4 text-2xl">どちらへアクセスしますか？</p>
     </div>
     <div class="mt-6">
-        <div class="text-center">
-            <button class="m-6 p-4 bg-blue-200 hover:bg-blue-600 shadow-xl">
-                <a href="https://vtuber.iris2664.com/" target="_blank" rel="noopener noreferrer">
-                    VTuber 東雲絢芽
-                </a>
-            </button>
-            <button class="m-4 p-4 bg-blue-200 hover:bg-blue-600 shadow-xl">
-                <a href="https://www.iris2664.com/" target="_blank" rel="noopener noreferrer">
-                    マネージャーのお姉さん 東雲絢芽
-                </a>
-            </button>
+        <div class="justify-center flex flex-wrap">
+            <div class="relative flex items-center m-4 p-4 bg-blue-200 hover:bg-blue-600 shadow-xl">
+                 <a href="https://vtuber.iris2664.com/" class="inset-0 absolute"> </a>
+                 <span class="place-items-center flex-0">
+                     VTuber 東雲絢芽
+                 </span>
+            </div>
+            <div class="relative flex items-center m-4 p-4 bg-blue-200 hover:bg-blue-600 shadow-xl">
+                 <a href="https://vtuber.iris2664.com/" class="inset-0 absolute"> </a>
+                 <span class="place-items-center flex-0">
+                     マネージャーのお姉さん 東雲絢芽
+                 </span>
+            </div>
         </div>
     </div>
 </body>
 </html>
+


### PR DESCRIPTION
# 概要
現状のリンクボタンは文字部分にしかリンクとしての当たり判定がないです．
リンクボタンのUX向上のための修正を行いました．

## 変更内容
- リンクボタンの当たり判定（クリック可能な領域）を拡大

## テスト項目
- [ ] 各種デバイス（デスクトップ、タブレット、スマートフォン）でのクリック操作の確認
- [ ] ボタンのデザインが崩れていないことの確認

レビューよろしくお願いいたします．